### PR TITLE
refactored function that sends scores to api

### DIFF
--- a/api/database.json
+++ b/api/database.json
@@ -14,12 +14,6 @@
       "id": 3,
       "name": "Helgen",
       "dateCreated": "01/05/2021"
-    },
-    {
-      "dateCreated": "5/12/2021, 10:03:13 PM",
-      "name": "Killer Wenches",
-      "id": 4,
-      "playerCount": 0
     }
   ],
   "players": [
@@ -92,13 +86,6 @@
       "country": "Canada",
       "teamId": 3,
       "id": 10
-    },
-    {
-      "firstName": "Caleb",
-      "lastName": "Inman",
-      "country": "USA",
-      "teamId": 4,
-      "id": 11
     }
   ],
   "scores": [
@@ -127,184 +114,40 @@
       "timestamp": 1620238696239
     },
     {
-      "id": 5,
-      "teamId": 2,
-      "score": 1,
-      "timestamp": 1620238696239
-    },
-    {
-      "id": 6,
-      "teamId": 3,
-      "score": 2,
-      "timestamp": 1620238696239
-    },
-    {
-      "id": 7,
       "teamId": 1,
-      "score": 1,
-      "timestamp": 1620238792447
-    },
-    {
-      "id": 8,
-      "teamId": 2,
-      "score": 1,
-      "timestamp": 1620238792447
-    },
-    {
-      "id": 9,
-      "teamId": 3,
-      "score": 1,
-      "timestamp": 1620238792447
+      "score": 3,
+      "timestamp": 1620923227294,
+      "id": 5
     },
     {
       "teamId": 2,
       "score": 3,
-      "timestamp": 1620856329197,
+      "timestamp": 1620923227307,
+      "id": 6
+    },
+    {
+      "teamId": 3,
+      "score": 3,
+      "timestamp": 1620923227319,
+      "id": 7
+    },
+    {
+      "teamId": 1,
+      "score": 3,
+      "timestamp": 1620923289294,
+      "id": 8
+    },
+    {
+      "teamId": 2,
+      "score": 3,
+      "timestamp": 1620923289307,
+      "id": 9
+    },
+    {
+      "teamId": 3,
+      "score": 3,
+      "timestamp": 1620923289319,
       "id": 10
-    },
-    {
-      "teamId": 1,
-      "score": 3,
-      "timestamp": 1620856329197,
-      "id": 11
-    },
-    {
-      "teamId": 3,
-      "score": 3,
-      "timestamp": 1620856329197,
-      "id": 12
-    },
-    {
-      "teamId": 1,
-      "score": 3,
-      "timestamp": 1620856422291,
-      "id": 13
-    },
-    {
-      "teamId": 2,
-      "score": 3,
-      "timestamp": 1620856422291,
-      "id": 14
-    },
-    {
-      "teamId": 3,
-      "score": 3,
-      "timestamp": 1620856422291,
-      "id": 15
-    },
-    {
-      "teamId": 2,
-      "score": 4,
-      "timestamp": 1620858996579,
-      "id": 16
-    },
-    {
-      "teamId": 1,
-      "score": 4,
-      "timestamp": 1620858996579,
-      "id": 17
-    },
-    {
-      "teamId": 3,
-      "score": 4,
-      "timestamp": 1620858996579,
-      "id": 18
-    },
-    {
-      "id": 19,
-      "teamId": 4,
-      "score": 0,
-      "timestamp": 1620874993700
-    },
-    {
-      "teamId": 1,
-      "score": 3,
-      "timestamp": 1620875048520,
-      "id": 20
-    },
-    {
-      "teamId": 4,
-      "score": 3,
-      "timestamp": 1620875048520,
-      "id": 21
-    },
-    {
-      "teamId": 3,
-      "score": 3,
-      "timestamp": 1620875048520,
-      "id": 22
-    },
-    {
-      "teamId": 1,
-      "score": 3,
-      "timestamp": 1620875120228,
-      "id": 23
-    },
-    {
-      "teamId": 4,
-      "score": 3,
-      "timestamp": 1620875120228,
-      "id": 24
-    },
-    {
-      "teamId": 3,
-      "score": 4,
-      "timestamp": 1620875120228,
-      "id": 25
-    },
-    {
-      "teamId": 1,
-      "score": 3,
-      "timestamp": 1620917312101,
-      "id": 26
-    },
-    {
-      "teamId": 2,
-      "score": 3,
-      "timestamp": 1620917312101,
-      "id": 27
-    },
-    {
-      "teamId": 4,
-      "score": 3,
-      "timestamp": 1620917312101,
-      "id": 28
-    },
-    {
-      "teamId": 1,
-      "score": 3,
-      "timestamp": 1620918267112,
-      "id": 29
-    },
-    {
-      "teamId": 3,
-      "score": 3,
-      "timestamp": 1620918267112,
-      "id": 30
-    },
-    {
-      "teamId": 4,
-      "score": 3,
-      "timestamp": 1620918267112,
-      "id": 31
-    },
-    {
-      "teamId": 1,
-      "score": 3,
-      "timestamp": 1620918295939,
-      "id": 32
-    },
-    {
-      "teamId": 2,
-      "score": 3,
-      "timestamp": 1620918295939,
-      "id": 33
-    },
-    {
-      "teamId": 3,
-      "score": 3,
-      "timestamp": 1620918295939,
-      "id": 34
     }
   ]
 }

--- a/src/scripts/Providers/ScoreProvider.js
+++ b/src/scripts/Providers/ScoreProvider.js
@@ -1,5 +1,5 @@
 // get current list of teams from app state in database
-import { getTeams, getTeam1CurrentScore, getTeam2CurrentScore, getTeam3CurrentScore, setTeam1score, setTeam2score, setTeam3score, getCurrentRound, setCurrentRound, sendCurrentScore, } from "../databaseAccess.js"
+import { getTeams, getTeam1CurrentScore, getTeam2CurrentScore, getTeam3CurrentScore, setTeam1score, setTeam2score, setTeam3score, getCurrentRound, setCurrentRound, sendCurrentScores, } from "../databaseAccess.js"
 import { currentGame } from "../Stats/Score.js";
 
 const mainContainer = document.querySelector("#container")
@@ -80,15 +80,7 @@ mainContainer.addEventListener(
         if (clickEvent.target.id === 'submitScores' && currentRound > 3) {
             const team1CurrentScore = getTeam1CurrentScore()
             team1CurrentScore.timestamp = Date.now()
-            const team2CurrentScore = getTeam2CurrentScore()
-            team2CurrentScore.timestamp = Date.now()
-            const team3CurrentScore = getTeam3CurrentScore()
-            team3CurrentScore.timestamp = Date.now()
-            sendCurrentScore(team1CurrentScore).then(
-            sendCurrentScore(team2CurrentScore)).then(
-            sendCurrentScore(team3CurrentScore)).then(
-            mainContainer.dispatchEvent(new CustomEvent('resetTempState'))).then(
-            mainContainer.dispatchEvent(new CustomEvent('stateChanged')))
+            sendCurrentScores(team1CurrentScore)
         }
     }
 )

--- a/src/scripts/databaseAccess.js
+++ b/src/scripts/databaseAccess.js
@@ -8,6 +8,7 @@ let applicationState = {
     CurrentRound: 1 
 }
 
+const mainContainer = document.querySelector("#container")
 
 
 // API fetch functions
@@ -90,27 +91,59 @@ export const setTeam3score = (score) => {
     applicationState.team3CurrentScore.score += score
 }
 
-export const sendCurrentScore = (currentScore) => {
+export const sendCurrentScores = (currentScore1) => {
     const fetchOptions = {
         method: "POST",
         headers: {
             "Content-Type": "application/json"
         },
-        body: JSON.stringify(currentScore)
+        body: JSON.stringify(currentScore1)
     }
 
 
     return fetch("http://localhost:8088/scores", fetchOptions)
         .then(response => response.json())
         .then(() => {
-            
+            applicationState.team2CurrentScore.timestamp = Date.now()
+            sendCurrentScore2(applicationState.team2CurrentScore)
         })
 }
 
-const mainContainer = document.querySelector("#container")
-mainContainer.addEventListener('resetTempState', customEvent => {
-    applicationState.team1CurrentScore = {}
-    applicationState.team2CurrentScore = {}
-    applicationState.team3CurrentScore = {}
-    applicationState.CurrentRound = 1
-})
+ const sendCurrentScore2 = (currentScore2) => {
+    const fetchOptions = {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json"
+        },
+        body: JSON.stringify(currentScore2)
+    }
+
+
+    return fetch("http://localhost:8088/scores", fetchOptions)
+        .then(response => response.json())
+        .then(() => {
+            applicationState.team3CurrentScore.timestamp = Date.now()
+            sendCurrentScore3(applicationState.team3CurrentScore)
+        })
+}
+
+const sendCurrentScore3 = (currentScore3) => {
+    const fetchOptions = {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json"
+        },
+        body: JSON.stringify(currentScore3)
+    }
+
+
+    return fetch("http://localhost:8088/scores", fetchOptions)
+        .then(response => response.json())
+        .then(() => {
+            applicationState.team1CurrentScore = {}
+            applicationState.team2CurrentScore = {}
+            applicationState.team3CurrentScore = {}
+            applicationState.CurrentRound = 1
+            mainContainer.dispatchEvent(new CustomEvent('stateChanged'))
+        })
+}


### PR DESCRIPTION
steps to test

1. pull this branch and open scoreProvider.js and databaseAccess.js
2. in the event listener that is triggered by the end of the third round, the only function that runs now is sendScores
3. the rest to the code is nested in functions in databaseAccess.js that run when sendScores is invoked
4. serve code to web browser
5. at the end of round 3, all 3 teams scores should be sent to the api, the temporary state should reset, and the html should re-render